### PR TITLE
Support custom loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ __createLogger(options?: Object)__
 #### __level (String)__
 Level of `console`. `warn`, `error`, `info` or [else](https://developer.mozilla.org/en/docs/Web/API/console).
 
+#### __logger (Object)__
+Implementation of the `console` API. Useful if you are using a custom, wrapped version of `console`.
+
 #### __collapsed (Boolean)__
 Is group collapsed?
 

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -10,7 +10,8 @@
 
 function createLogger(options = {}) {
   return ({ getState }) => (next) => (action) => {
-    const { level, collapsed, predicate } = options;
+    const { level, collapsed, predicate, logger } = options;
+    const console = logger || console;
 
     // exit if console undefined
     if (typeof console === 'undefined') {


### PR DESCRIPTION
Fixes #3 by adding an option to pass a custom logger implementation instead of `console`