### PR TITLE
Add support for Symbol action types

### DIFF
--- a/build/createLogger.js
+++ b/build/createLogger.js
@@ -41,7 +41,8 @@ function createLogger() {
         var returnValue = next(action);
         var nextState = getState();
         var time = new Date();
-        var message = 'action ' + action.type + ' @ ' + time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds();
+        var actionType = String(action.type);
+        var message = 'action ' + actionType + ' @ ' + time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds();
 
         if (collapsed) {
           try {

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -27,7 +27,8 @@ function createLogger(options = {}) {
     const returnValue = next(action);
     const nextState = getState();
     const time = new Date();
-    const message = `action ${action.type} @ ${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`;
+    const actionType = String(action.type);
+    const message = `action ${actionType} @ ${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`;
 
     if (collapsed) {
       try {


### PR DESCRIPTION
I've been working on an app where we're using Symbols as the action types.  Using redux-logger in this case throws an exception since Symbol doesn't support string concatenation.  So this small patch manually coerces the action type to a string before attempting to log it.