### PR TITLE
fix typo in transformer option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Receives `getState` function for  accessing current store state and `action` obj
 
 *Default: `null` (always log)*
 
-#### __transform (Function)__
+#### __transformer (Function)__
 Transform state before print. Eg. convert Immutable object to plain JSON.
 
 *Default: identity function*


### PR DESCRIPTION
Property name `transformer` in the README now matches the code.