### PR TITLE
Add timestamp option + pad hours/minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Transform state before print. Eg. convert Immutable object to plain JSON.
 
 *Default: identity function*
 
+#### __timestamp (Boolean)__
+Print timestamp with each action?
+
+*Default: `true`*
+
 
 ##### Examples:
 ###### log only in dev mode

--- a/build/createLogger.js
+++ b/build/createLogger.js
@@ -1,3 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+var pad = function pad(num) {
+  return ('0' + num).slice(-2);
+};
+
 /**
  * Creates logger with followed options
  *
@@ -8,11 +17,6 @@
  * @property {bool} predicate - condition which resolves logger behavior
  */
 
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
 function createLogger() {
   var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
 
@@ -28,6 +32,8 @@ function createLogger() {
         var transformer = _options$transformer === undefined ? function (state) {
           return state;
         } : _options$transformer;
+        var _options$timestamp = options.timestamp;
+        var timestamp = _options$timestamp === undefined ? true : _options$timestamp;
 
         var console = logger || window.console;
 
@@ -44,9 +50,13 @@ function createLogger() {
         var prevState = transformer(getState());
         var returnValue = next(action);
         var nextState = transformer(getState());
-        var time = new Date();
+        var formattedTime = '';
+        if (timestamp) {
+          var time = new Date();
+          formattedTime = ' @ ' + time.getHours() + ':' + pad(time.getMinutes()) + ':' + pad(time.getSeconds());
+        }
         var actionType = String(action.type);
-        var message = 'action ' + actionType + ' @ ' + time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds();
+        var message = 'action ' + actionType + formattedTime;
 
         if (collapsed) {
           try {

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -1,3 +1,5 @@
+const pad = num => ('0' + num).slice(-2);
+
 /**
  * Creates logger with followed options
  *
@@ -10,7 +12,7 @@
 
 function createLogger(options = {}) {
   return ({ getState }) => (next) => (action) => {
-    const { level, collapsed, predicate, logger, transformer = state => state} = options;
+    const { level, collapsed, predicate, logger, transformer = state => state, timestamp = true} = options;
     const console = logger || window.console;
 
     // exit if console undefined
@@ -26,9 +28,13 @@ function createLogger(options = {}) {
     const prevState = transformer(getState());
     const returnValue = next(action);
     const nextState = transformer(getState());
-    const time = new Date();
+    let formattedTime = '';
+    if (timestamp) {
+      const time = new Date();
+      formattedTime = ` @ ${time.getHours()}:${pad(time.getMinutes())}:${pad(time.getSeconds())}`;
+    }
     const actionType = String(action.type);
-    const message = `action ${actionType} @ ${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`;
+    const message = `action ${actionType}${formattedTime}`;
 
     if (collapsed) {
       try {


### PR DESCRIPTION
* Added `timestamp` (default `true`) option to disable timestamp printing.
* Pad numbers with zeros in timestamp (e.g. `1:8:5` becomes `1:08:05`).