### PR TITLE
fix patch for immutable transform example when there are multiple reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ createLogger({
 ```javascript
 createLogger({
   transformer: (state) => {
+    var newState = {};
     for (var i of Object.keys(state)) {
       if (Immutable.Iterable.isIterable(state[i])) {
-        return state[i].toJS();
+        newState[i] = state[i].toJS();
       } else {
-        return state[i];
+        newState[i] = state[i];
       }
     };
+    return newState;
   }
 });
 ```


### PR DESCRIPTION
I updated the README per comments in #22 and I've verified.

Only state from the first reducer is logged, so this did not perform as expected when there were multiple reducers.  This patch fixes that issue per feedback from @alakiikonen.