### PR TITLE
Add option for action type transforming

### DIFF
--- a/build/createLogger.js
+++ b/build/createLogger.js
@@ -31,6 +31,10 @@ function createLogger() {
         var collapsed = options.collapsed;
         var predicate = options.predicate;
         var logger = options.logger;
+        var _options$typeToString = options.typeToString;
+        var typeToString = _options$typeToString === undefined ? function (type) {
+          return String(type);
+        } : _options$typeToString;
         var _options$transformer = options.transformer;
         var transformer = _options$transformer === undefined ? function (state) {
           return state;
@@ -66,7 +70,7 @@ function createLogger() {
         if (duration) {
           formattedDuration = ' in ' + took.toFixed(2) + ' ms';
         }
-        var actionType = String(action.type);
+        var actionType = typeToString(action.type);
         var message = 'action ' + actionType + formattedTime + formattedDuration;
 
         var isCollapsed = typeof collapsed === 'function' ? collapsed(getState, action) : collapsed;

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -15,7 +15,10 @@ const timer = typeof performance !== 'undefined' && typeof performance.now === '
 
 function createLogger(options = {}) {
   return ({ getState }) => (next) => (action) => {
-    const { level, collapsed, predicate, logger, transformer = state => state, timestamp = true, duration = false } = options;
+    const { level, collapsed, predicate, logger,
+      typeToString = type => String(type),
+      transformer = state => state,
+      timestamp = true, duration = false } = options;
     const console = logger || window.console;
 
     // exit if console undefined
@@ -42,7 +45,7 @@ function createLogger(options = {}) {
     if (duration) {
       formattedDuration = ` in ${took.toFixed(2)} ms`;
     }
-    const actionType = String(action.type);
+    const actionType = typeToString(action.type);
     const message = `action ${actionType}${formattedTime}${formattedDuration}`;
 
     const isCollapsed = (typeof collapsed === 'function') ?


### PR DESCRIPTION
Hi, thank a lot for great logger!

Option for action type transforming will be helpful, if action type is a number (for example, member of some enum). In this case for pretty logging you can provide typeToString function like this:
```javascript
const enum = {
  1: 'action_one',
  2: 'action_two',
  action_one: 1,
  action_two: 2
};

import createLogger from 'redux-logger';
const logger = createLogger({
  typeToString: (type) => enum[type]
});

// ...
// and somewhere in app
dispatch({type: enum.action_one});
```