### PR TITLE
Fix collapsed option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ function createLogger(options = {}) {
 
     // render
     try {
-      startMessage(message);
+      startMessage.call(console, message);
     } catch (e) {
       console.log(message);
     }


### PR DESCRIPTION
Must be called on console itself, otherwise it doesn’t work.