### PR TITLE
Implemented `postProcessor` option, a tweaked version of `predicate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Receives `getState` function for  accessing current store state and `action` obj
 
 *Default: `null` (always log)*
 
+#### __postProcessor (prevState: Object, nextState: Object, action: Object): object__
+If specified this function will be called after each action is processed with this middleware.
+Receives `prevState` object for previous store state, `nextState` object for next store state, and `action` object as parameters. Returns `false` if action should not be logged, or object `object` to change output settings, `false` otherwise.
+`object` is expected in format `{color:string}`, where `color` will be applied to the grouping log message
+
+*Default: `null` (always log)*
+
 #### __duration (Boolean)__
 Print duration of each action?
 
@@ -82,6 +89,13 @@ createLogger({
 ```javascript
 createLogger({
   predicate: (getState, action) => action.type !== AUTH_REMOVE_TOKEN
+});
+```
+
+#### log collapsed group message in gray color if state has not been mutated
+```javascript
+createLogger({
+  postProcessor: (prevState, nextState, action) => prevState === nextState ? { color: "#ccc" } : true
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ createLogger({
 #### log collapsed group message in gray color if state has not been mutated
 ```javascript
 createLogger({
-  postProcessor: (prevState, nextState, action) => prevState === nextState ? { color: "#ccc" } : true
+  postProcessor: (prevState, nextState, action) => {
+    return prevState === nextState ? { color: "#ccc" } : true
+  }
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const timer = typeof performance !== `undefined` && typeof performance.now === `
  * @property {object} options.logger - implementation of the `console` API.
  * @property {boolean} options.collapsed - is group collapsed?
  * @property {boolean} options.predicate - condition which resolves logger behavior
+ * @property {object} options.postProcessor - condition which resolves logger behavior
  * @property {bool} options.duration - print duration of each action?
  * @property {bool} options.timestamp - print timestamp with each action?
  * @property {function} options.transformer - transform state before print
@@ -26,6 +27,7 @@ function createLogger(options = {}) {
       logger,
       collapsed,
       predicate,
+      postProcessor,
       duration = false,
       timestamp = true,
       transformer = state => state,


### PR DESCRIPTION
I wanted to have a control on output, basing on `prevState`, `nextState` and `action` altogether.
Main goal was to greyout (or not to show at all) log messages of actions which did not cause store state mutation.