### PR TITLE
fix: prevState and nextState being same

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ function createLogger(options = {}) {
     const prevState = stateTransformer(getState());
 
     const formattedAction = actionTransformer(action);
+    const returnedValue = next(action);
 
     const took = timer.now() - started;
     const nextState = stateTransformer(getState());
@@ -96,7 +97,7 @@ function createLogger(options = {}) {
       logger.log(`—— log end ——`);
     }
 
-    return next(action);
+    return returnedValue;
   };
 }
 


### PR DESCRIPTION
```diff
    const started = timer.now();
    const prevState = stateTransformer(getState());

    const formattedAction = actionTransformer(action);
+   const returnedValue = next(action);

    const took = timer.now() - started;
    const nextState = stateTransformer(getState());

-   return next(action);
+   return returnedValue;
```

prevState and nextState is same because `next(action)` doesn't get executed between prevState and nextState.
This pull request fixes the problem by putting `next(action)` between them.