### PR TITLE
Remove log of 'false' when timestamp or duration logging disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ function createLogger(options = {}) {
     const isCollapsed = (typeof collapsed === `function`) ? collapsed(getState, action) : collapsed;
 
     const formattedTime = formatTime(time);
-    const title = `action ${formattedAction.type}${timestamp && formattedTime}${duration && ` in ${took.toFixed(2)} ms`}`;
+    const title = `action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
 
     // render
     try {


### PR DESCRIPTION
When configuring the middleware with the following option object:
````
{
    collapsed: true,
    stateTransformer: stateToJS,
}
```
It will log `action MY_ACTION_NAME @ 17:20:39.566false`. Same thing if manually disabling the timestamp (`timestamp: false`). This commit should fix that.

If you'd prefer to do it otherwise, let me know, I'll update the PR :)