### PR TITLE
Add titleStyle option for adding CSS to title text

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Print timestamp with each action?
 *Default: `true`*
 
 #### __colors (Object)__
-Object with 3 functions: `prevState`, `action`, `nextState`. Useful if you want paint message based on specific state or action. It also can be `false` if you want show plain message without colors.
+Object with 4 functions: `title`, `prevState`, `action`, `nextState`. Useful if you want paint message based on specific state or action. It also can be `false` if you want show plain message without colors.
 
+* `title(action: Object) => color: String`
 * `prevState(prevState: Object) => color: String`
 * `action(action: Object) => color: String`
 * `nextState(nextState: Object) => color: String`

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const timer = typeof performance !== `undefined` && typeof performance.now === `
  * @property {string} options.level - console[level]
  * @property {bool} options.duration - print duration of each action?
  * @property {bool} options.timestamp - print timestamp with each action?
- * @property {object} options.colors - custom colors for group contents
+ * @property {object} options.colors - custom colors
  * @property {object} options.logger - implementation of the `console` API
  * @property {boolean} options.collapsed - is group collapsed?
  * @property {boolean} options.predicate - condition which resolves logger behavior
@@ -28,7 +28,6 @@ function createLogger(options = {}) {
       logger = window.console,
       collapsed,
       predicate,
-      titleStyle,
       duration = false,
       timestamp = true,
       transformer, // deprecated
@@ -70,7 +69,7 @@ function createLogger(options = {}) {
     const isCollapsed = (typeof collapsed === `function`) ? collapsed(getState, action) : collapsed;
 
     const formattedTime = formatTime(time);
-    const titleCSS = `color: ${colors.title(action)};`
+    const titleCSS = `color: ${colors.title(action)};`;
     const title = `%c action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
 
     // render

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const timer = typeof performance !== `undefined` && typeof performance.now === `
  * @property {string} options.level - console[level]
  * @property {bool} options.duration - print duration of each action?
  * @property {bool} options.timestamp - print timestamp with each action?
- * @property {object} options.colors - custom colors
+ * @property {object} options.colors - custom colors for group contents
  * @property {object} options.logger - implementation of the `console` API
  * @property {boolean} options.collapsed - is group collapsed?
  * @property {boolean} options.predicate - condition which resolves logger behavior
@@ -28,12 +28,14 @@ function createLogger(options = {}) {
       logger = window.console,
       collapsed,
       predicate,
+      titleStyle,
       duration = false,
       timestamp = true,
       transformer, // deprecated
       stateTransformer = state => state,
       actionTransformer = actn => actn,
       colors = {
+        title: () => `#000000`,
         prevState: () => `#9E9E9E`,
         action: () => `#03A9F4`,
         nextState: () => `#4CAF50`,
@@ -68,14 +70,15 @@ function createLogger(options = {}) {
     const isCollapsed = (typeof collapsed === `function`) ? collapsed(getState, action) : collapsed;
 
     const formattedTime = formatTime(time);
-    const title = `action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
+    const titleCSS = `color: ${colors.title(action)};`
+    const title = `%c action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
 
     // render
     try {
       if (isCollapsed) {
-        logger.groupCollapsed(title);
+        logger.groupCollapsed(title, titleCSS);
       } else {
-        logger.group(title);
+        logger.group(title, titleCSS);
       }
     } catch (e) {
       logger.log(title);


### PR DESCRIPTION
This is something I've found really useful, I collapse all log items and can see errors at a glance, without opening up groups. Also handy for coloring pending/fetching actions.