### PR TITLE
fix logger order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ function createLogger(options = {}) {
   const logBuffer = [];
   function printBuffer() {
     logBuffer.forEach((logEntry, key) => {
-      let { started, took, action, prevState, nextState } = logEntry;
+      const { started, action, prevState } = logEntry;
+      let { took, nextState } = logEntry;
       const nextEntry = logBuffer[key + 1];
       if (nextEntry) {
         nextState = nextEntry.prevState;

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,6 @@ function createLogger(options = {}) {
   }
 
   return ({ getState }) => (next) => (action) => {
-
     // exit early if predicate function returns false
     if (typeof predicate === `function` && !predicate(getState, action)) {
       return next(action);


### PR DESCRIPTION
When redux dispatch an action, after calling the reducer, the listeners
will be called. If the listener dispatch a new action, redux allow it,
but the order of the log will in reverse.
this PR fix the order in that case.