### PR TITLE
Fixed webpack compatibility issue with ES6 exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,4 +104,5 @@ function createLogger(options = {}) {
   };
 }
 
-export default createLogger;
+module.exports = createLogger;
+


### PR DESCRIPTION
Webpack has an issue interpreting ES6 exports from the root file. The end result causes createLogger to be wrapped in a an Object. By replacing the ES6 syntax with the default module system, as done in this PR, the issue is resolved

example of problem:
```javascript
let createLogger = require('redux-logger');
console.log(createLogger);
/*
Object {
__esModule: true
default: createLogger()
__proto__: Object
}
*/
```
##### Examples of identical issues and resolutions: 
Quick glance of problem: https://github.com/algolia/instantsearch.js/pull/725
Deeper Explanation/Description of the issue: https://github.com/webpack/webpack/issues/706
Example of an identical fix: https://github.com/algolia/instantsearch.js/commit/81e7eee18bbd32014939f5ed61035d52a73f1ae6#diff-168726dbe96b3ce427e7fedce31bb0bc