### PR TITLE
Symbols will not work with normal String concat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ function createLogger(options = {}) {
 
     const formattedTime = formatTime(time);
     const titleCSS = colors.title ? `color: ${colors.title(formattedAction)};` : null;
-    const title = `action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
+    const title = `action ${String(formattedAction.type)}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
 
     // render
     try {


### PR DESCRIPTION
An example pulled from the Chrome Devtools Console:

```
const INCREMENT_COUNTER = Symbol('INCREMENT_COUNTER');
INCREMENT_COUNTER + "Hello"
VM222:2 Uncaught TypeError: Cannot convert a Symbol value to a string(…)
```

The fix is simple, coerce to a String by invoking the constructor around it.

I am surprised this wasn't already added since I can see `Symbol(...)` working correctly in the README screenshot.