### PR TITLE
fix web worker window crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function createLogger(options = {}) {
   return ({ getState }) => (next) => (action) => {
     const {
       level = `log`,
-      logger = window.console,
+      logger = (self || window).console,
       logErrors = true,
       collapsed,
       predicate,


### PR DESCRIPTION
I have been trying an experiment using redux and redux-logger from a web worker. Currently redux-logger crashes on load. This is due to redux-logger having a reference to window. [Referencing window from a web worker currently throws an error](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers). 'self' is the global scope for a web worker instead of window. By checking if self exists before trying to use window, it will circumvent crashes in web workers. 

If this change is something you're not willing to include, feel free to ignore my pull request. I just figured I'd pass along my findings.