### PR TITLE
Fix a bug where next state was not logged when an error was logged

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,10 +95,10 @@ function createLogger(options = {}) {
       if (error) {
         if (colors.error) logger[level](`%c error`, `color: ${colors.error(error, prevState)}; font-weight: bold`, error);
         else logger[level](`error`, error);
-      } else {
-        if (colors.nextState) logger[level](`%c next state`, `color: ${colors.nextState(nextState)}; font-weight: bold`, nextState);
-        else logger[level](`next state`, nextState);
       }
+      
+      if (colors.nextState) logger[level](`%c next state`, `color: ${colors.nextState(nextState)}; font-weight: bold`, nextState);
+      else logger[level](`next state`, nextState);
 
       try {
         logger.groupEnd();

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function createLogger(options = {}) {
         if (colors.error) logger[level](`%c error`, `color: ${colors.error(error, prevState)}; font-weight: bold`, error);
         else logger[level](`error`, error);
       }
-      
+
       if (colors.nextState) logger[level](`%c next state`, `color: ${colors.nextState(nextState)}; font-weight: bold`, nextState);
       else logger[level](`next state`, nextState);
 


### PR DESCRIPTION
Here's a fix for #114. I was not able to run the tests, I got this issue:

```
~/s/redux-logger (master) $ npm test

> redux-logger@2.3.1 test /Users/ericcapps/src/redux-logger
> npm run lint


> redux-logger@2.3.1 lint /Users/ericcapps/src/redux-logger
> $(npm bin)/eslint src

sh: /Users/ericcapps/src/redux-logger/node_modules/.bin/eslint: No such file or directory

npm ERR! Darwin 15.2.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v4.2.3
npm ERR! npm  v2.14.7
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! redux-logger@2.3.1 lint: `$(npm bin)/eslint src`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the redux-logger@2.3.1 lint script '$(npm bin)/eslint src'.
npm ERR! This is most likely a problem with the redux-logger package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     $(npm bin)/eslint src
npm ERR! You can get their info via:
npm ERR!     npm owner ls redux-logger
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/ericcapps/src/redux-logger/npm-debug.log
npm ERR! Test failed.  See above for more details.
```