### PR TITLE
remove window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const timer = typeof performance !== `undefined` && typeof performance.now === `
 function createLogger(options = {}) {
   const {
     level = `log`,
-    logger = window.console,
+    logger = console,
     logErrors = true,
     collapsed,
     predicate,


### PR DESCRIPTION
Assuming the existence of window means redux-logger cannot be used in universal applications. 

This removes the dependency on window being the global variable. 