### PR TITLE
Support symbol action types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ function createLogger(options = {}) {
 
       const formattedTime = formatTime(time);
       const titleCSS = colors.title ? `color: ${colors.title(formattedAction)};` : null;
-      const title = `action ${formattedAction.type}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
+      const title = `action ${String(formattedAction.type)}${timestamp ? formattedTime : ``}${duration ? ` in ${took.toFixed(2)} ms` : ``}`;
 
       // render
       try {


### PR DESCRIPTION
Symbol action types cause an error as they are not implicitly converted
to strings when trying to concatenate them with another string.
This just wraps the action type in String(...) when it is being printed so
it should work regardless of the typeof the action type constant.