### PR TITLE
Updated syntax for recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,7 @@ createLogger({
 ```javascript
 import { Iterable } from 'immutable';
 
-const stateTransformer = (state) => {
-  if (Iterable.isIterable(state)) return state.toJS();
-  else return state;
-};
+const stateTransformer = (state) => Iterable.isIterable(state) ? state.toJS() : state;
 
 const logger = createLogger({
   stateTransformer,
@@ -220,20 +217,13 @@ const logger = createLogger({
 
 ### Transform Immutable (with `combineReducers`)
 ```javascript
+import { Iterable } from 'immutable';
+
 const logger = createLogger({
-  stateTransformer: (state) => {
-    let newState = {};
-
-    for (var i of Object.keys(state)) {
-      if (Immutable.Iterable.isIterable(state[i])) {
-        newState[i] = state[i].toJS();
-      } else {
-        newState[i] = state[i];
-      }
-    };
-
+  stateTransformer: (state) => Object.keys(state).reduce((newState, key) => {
+    newState[key] = Iterable.isIterable(state[key]) ? state[key].toJS() : state[key];
     return newState;
-  }
+  }, {}),
 });
 ```
 


### PR DESCRIPTION
`redux-logger` is awesome, thanks for making it!

## Issue
The existing recipe for [Transform Immutable (with combineReducers)](https://github.com/evgenyrodionov/redux-logger/blob/master/README.md#transform-immutable-with-combinereducers) uses `let` and `var` when `const` should be used, and has an unneeded `;`.  

## Fix
I've refactored the examples to be more functional with appropriate variable usage.

## Before:
![screen shot 2017-11-30 at 10 46 52 am](https://user-images.githubusercontent.com/5858247/33449473-bc41251a-d5bd-11e7-9ab2-3415f100e63a.png)

## After:
![screen shot 2017-11-30 at 10 47 12 am](https://user-images.githubusercontent.com/5858247/33449070-8ed733cc-d5bc-11e7-996b-0736171d7e58.png)

