### PR TITLE
chore: use ddiff

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,13 +63,12 @@
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^1.0.2",
     "tslib": "^1.9.0",
     "typescript": "^2.8.0-rc"
   },
   "dependencies": {
-    "deep-diff": "^0.3.5"
+    "ddiff": "^0.1.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from 'rollup-plugin-babel';
-import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import uglify from 'rollup-plugin-uglify';
 
@@ -22,13 +21,8 @@ export default {
       ],
       plugins: ['external-helpers'],
     }),
-    commonjs({
-      include: 'node_modules/**',
-    }),
     nodeResolve({
       jsnext: true,
-      main: true,
-      browser: true,
     }),
     uglify(),
   ],

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,4 +1,4 @@
-import differ from 'deep-diff';
+import { diff as differ } from 'ddiff';
 
 // https://github.com/flitbit/diff#differences
 const dictionary = {
@@ -54,7 +54,7 @@ export default function diffLogger(prevState, newState, logger, isCollapsed) {
     logger.log('diff');
   }
 
-  if (diff) {
+  if (diff.length) {
     diff.forEach((elem) => {
       const { kind } = elem;
       const output = render(elem);


### PR DESCRIPTION
Use [ddiff](https://github.com/thiamsantos/ddiff) instead of [deep-diff](https://github.com/flitbit/diff), ref #273.

By doing this change was possible to decrease the final bundle size of redux-logger from `3.59 kb` gziped to `2.98 kb` gziped. And simplify the rollup configuration by removing the [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs) because ddiff exposes an es module build.