### PR TITLE
Flagged module as side effect free to enhance tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "url": "https://github.com/theaqua/redux-logger/issues"
   },
   "homepage": "https://github.com/theaqua/redux-logger#readme",
+  "sideEffects": false,
   "devDependencies": {
     "babel-core": "^6.24.0",
     "babel-plugin-external-helpers": "^6.22.0",


### PR DESCRIPTION
Added `sideEffects` flag to `package.json` to allow the tree shaking feature of webpack to totally disregard this module when imported.

A somewhat normal use case of `redux-logger` could be:
```bash
import { createStore, applyMiddleware } from 'redux';
import thunkMiddleware from 'redux-thunk';
import { createLogger } from './redux-logger';
import Reducer from './Reducer';

let store = createStore(Reducer, applyMiddleware(thunkMiddleware));

if (process.env.NODE_ENV !== 'production') {
   const loggerMiddleware = createLogger();
   store = createStore(Reducer, applyMiddleware(thunkMiddleware, loggerMiddleware));
}
```

When building for `production`, current Webpack behavior is to exclude anything inside the `process.env.NODE_ENV !== 'production'` conditional, but not remove the `import { createLogger } from './redux-logger';`. Since we are not using the logger in any way, it would be nice to totally disregard it from the production build. Adding the `"sideEffects": false` flag to `package.json` will achieve exactly that.