### PR TITLE
Remove old "require" statement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,16 +184,17 @@ Filter states diff for certain cases.
 ## Recipes
 ### Log only in development
 ```javascript
+import logger from 'redux-logger'
+
 const middlewares = [];
 
 if (process.env.NODE_ENV === `development`) {
-  const { logger } = require(`redux-logger`);
-
   middlewares.push(logger);
 }
 
 const store = compose(applyMiddleware(...middlewares))(createStore)(reducer);
 ```
+*Note that NODE_ENV can be one of `development`, `test` or `production`.*
 
 ### Log everything except actions with certain type
 ```javascript


### PR DESCRIPTION
Does exactly what the title says. There was still a very old `require` statement in the `Log only in development` part of the README docs. This PR changes that for an ES6 Import statement.


I've also added a note that `NODE_ENV` can only be `test`. This is interesting to note for end-users since (probably among others) React-Scripts from Create-React-App sets NODE_ENV to `test` when running their test script. 