### PR TITLE
docs: README.md allot log only in development usage of flag __DEV__

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Filter states diff for certain cases.
 ```javascript
 const middlewares = [];
 
-if (process.env.NODE_ENV === `development`) {
-  const { logger } = require(`redux-logger`);
+if (process.env.NODE_ENV === "development" || __DEV__) {
+  const { logger } = require("redux-logger");
 
   middlewares.push(logger);
 }


### PR DESCRIPTION
## Description

This PR add flag `__DEV__` check when you want to enable only in development.