### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now maintained by [LogRocket](https://logrocket.com?cid=github_redux)!
 
 > LogRocket is a production Redux logging tool that lets you replay problems as if they happened in your own browser. Instead of guessing why errors happen, or asking users for screenshots and log dumps, LogRocket lets you replay Redux actions + state, network requests, console logs, and see a video of what the user saw.
 
-For more informatiom about the future of redux-logger, check out the [discussion here](https://github.com/LogRocket/redux-logger/issues/314).
+For more information about the future of redux-logger, check out the [discussion here](https://github.com/LogRocket/redux-logger/issues/314).
 
 ## Table of contents
 * [Install](#install)


### PR DESCRIPTION
I fixed the typo "informatiom" -> "information", because it bothered me too much.