### PR TITLE
chore: move console messages to their own module

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 import { applyMiddleware, createStore } from 'redux';
 import { default as logger, createLogger } from '../src';
+import { REDUX_LOGGER_NOT_INSTALLED, REDUX_LOGGER_V3_BREAKING_CHANGE } from '../src/messages';
 
 context('default logger', () => {
   describe('init', () => {
@@ -18,6 +19,30 @@ context('default logger', () => {
       store.dispatch({ type: 'foo' });
       sinon.assert.notCalled(console.error);
     });
+
+    describe('when exported default logger is used improperly', () => {
+      it('should log a breaking change error message once', () => {
+        try {
+          createStore(() => ({}), applyMiddleware(logger()));
+        } catch (e) {
+          sinon.assert.calledOnce(console.error);
+          sinon.assert.calledWith(console.error, REDUX_LOGGER_V3_BREAKING_CHANGE)
+          return null;
+        }
+
+        sinon.assert.fail('Creating a store when improperly using the exported default logger should raise an error');
+      });
+
+      it('should throw a runtime error', () => {
+        try {
+          createStore(() => ({}), applyMiddleware(logger()));
+        } catch (e) {
+          return null;
+        }
+
+        sinon.assert.fail('Creating a store when improperly using the exported default logger should raise an error');
+      });
+    })
   });
 });
 
@@ -36,6 +61,7 @@ context('createLogger', () => {
 
       store.dispatch({ type: 'foo' });
       sinon.assert.calledOnce(console.error);
+      sinon.assert.calledWith(console.error, REDUX_LOGGER_NOT_INSTALLED);
     });
 
     it('should be ok', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 import printBuffer from './core';
 import { timer } from './helpers';
 import defaults from './defaults';
-import { REDUX_LOGGER_NOT_INSTALLED, REDUX_LOGGER_V3_BREAKING_CHANGE } from './messages';
+import {
+  REDUX_LOGGER_NOT_INSTALLED as REDUX_LOGGER_NOT_INSTALLED_MESSAGE,
+  REDUX_LOGGER_V3_BREAKING_CHANGE as REDUX_LOGGER_V3_BREAKING_CHANGE_MESSAGE,
+} from './messages';
 
 /* eslint max-len: ["error", 110, { "ignoreComments": true }] */
 /**
@@ -43,7 +46,7 @@ function createLogger(options = {}) {
   // Detect if 'createLogger' was passed directly to 'applyMiddleware'.
   if (options.getState && options.dispatch) {
     // eslint-disable-next-line no-console
-    console.error(REDUX_LOGGER_NOT_INSTALLED);
+    console.error(REDUX_LOGGER_NOT_INSTALLED_MESSAGE);
 
     return () => next => action => next(action);
   }
@@ -97,7 +100,7 @@ const defaultLogger = ({ dispatch, getState } = {}) => {
     return createLogger()({ dispatch, getState });
   }
   // eslint-disable-next-line no-console
-  console.error(REDUX_LOGGER_V3_BREAKING_CHANGE);
+  console.error(REDUX_LOGGER_V3_BREAKING_CHANGE_MESSAGE);
 };
 
 export { defaults, createLogger, defaultLogger as logger };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import printBuffer from './core';
 import { timer } from './helpers';
 import defaults from './defaults';
+import { REDUX_LOGGER_NOT_INSTALLED, REDUX_LOGGER_V3_BREAKING_CHANGE } from './messages';
+
 /* eslint max-len: ["error", 110, { "ignoreComments": true }] */
 /**
  * Creates logger with following options
@@ -41,23 +43,7 @@ function createLogger(options = {}) {
   // Detect if 'createLogger' was passed directly to 'applyMiddleware'.
   if (options.getState && options.dispatch) {
     // eslint-disable-next-line no-console
-    console.error(`[redux-logger] redux-logger not installed. Make sure to pass logger instance as middleware:
-// Logger with default options
-import { logger } from 'redux-logger'
-const store = createStore(
-  reducer,
-  applyMiddleware(logger)
-)
-// Or you can create your own logger with custom options http://bit.ly/redux-logger-options
-import { createLogger } from 'redux-logger'
-const logger = createLogger({
-  // ...options
-});
-const store = createStore(
-  reducer,
-  applyMiddleware(logger)
-)
-`);
+    console.error(REDUX_LOGGER_NOT_INSTALLED);
 
     return () => next => action => next(action);
   }
@@ -111,14 +97,7 @@ const defaultLogger = ({ dispatch, getState } = {}) => {
     return createLogger()({ dispatch, getState });
   }
   // eslint-disable-next-line no-console
-  console.error(`
-[redux-logger v3] BREAKING CHANGE
-[redux-logger v3] Since 3.0.0 redux-logger exports by default logger with default settings.
-[redux-logger v3] Change
-[redux-logger v3] import createLogger from 'redux-logger'
-[redux-logger v3] to
-[redux-logger v3] import { createLogger } from 'redux-logger'
-`);
+  console.error(REDUX_LOGGER_V3_BREAKING_CHANGE);
 };
 
 export { defaults, createLogger, defaultLogger as logger };

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,0 +1,31 @@
+const REDUX_LOGGER_NOT_INSTALLED = `[redux-logger] redux-logger not installed. Make sure to pass logger instance as middleware:
+// Logger with default options
+import { logger } from 'redux-logger'
+const store = createStore(
+  reducer,
+  applyMiddleware(logger)
+)
+// Or you can create your own logger with custom options http://bit.ly/redux-logger-options
+import { createLogger } from 'redux-logger'
+const logger = createLogger({
+  // ...options
+});
+const store = createStore(
+  reducer,
+  applyMiddleware(logger)
+)
+`;
+
+const REDUX_LOGGER_V3_BREAKING_CHANGE = `
+[redux-logger v3] BREAKING CHANGE
+[redux-logger v3] Since 3.0.0 redux-logger exports by default logger with default settings.
+[redux-logger v3] Change
+[redux-logger v3] import createLogger from 'redux-logger'
+[redux-logger v3] to
+[redux-logger v3] import { createLogger } from 'redux-logger'
+`;
+
+export {
+  REDUX_LOGGER_NOT_INSTALLED,
+  REDUX_LOGGER_V3_BREAKING_CHANGE,
+};


### PR DESCRIPTION
### Summary

The `console.error` messages are effectively constants that make reading the logic in `index.js` slightly more tedious.

By moving these message strings to their own module, this slightly cleans up the logic in `index.js`.

Also, this adds some tests for whether these `console.error`s were called with the appropriate text.

Definitely understandable if this isn't merged as this type of code organization can be more a matter of taste than anything else.