### PR TITLE
build: Flagged module as sideEffects false to enhance tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "precommit": "npm test && npm run lint",
     "prepublish": "npm run clean && npm test && npm run lint && npm run build"
   },
+  "sideEffects": false,
   "eslintConfig": {
     "extends": "airbnb",
     "rules": {


### PR DESCRIPTION
The current v4 version already supports the ES module, so in order for webpack packaging to work properly for treeshaking, you should mark the sideEffects here.